### PR TITLE
LMN 1672 | heart rate android toggle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.metaflow.flutterhealthfit'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.android.gms:play-services-fitness:18.0.0'
-    implementation 'com.google.android.gms:play-services-auth:17.0.0'
+    implementation 'com.google.android.gms:play-services-fitness:20.0.0'
+    implementation 'com.google.android.gms:play-services-auth:19.0.0'
 }

--- a/android/src/main/kotlin/com/metaflow/flutterhealthfit/FlutterHealthFitPlugin.kt
+++ b/android/src/main/kotlin/com/metaflow/flutterhealthfit/FlutterHealthFitPlugin.kt
@@ -17,7 +17,6 @@ import com.google.android.gms.fitness.data.DataPoint
 import com.google.android.gms.fitness.data.DataSource
 import com.google.android.gms.fitness.data.DataType
 import com.google.android.gms.fitness.request.DataReadRequest
-import com.google.android.gms.fitness.result.DataReadResponse
 import com.google.android.gms.tasks.Tasks
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -37,6 +36,7 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
 
     companion object {
         private const val GOOGLE_FIT_PERMISSIONS_REQUEST_CODE = 1
+        private const val GOOGLE_FIT_SENSITIVE_PERMISSIONS_REQUEST_CODE = 4723747
         private const val SENSOR_PERMISSION_REQUEST_CODE = 9174802
 
         val stepsDataType: DataType = DataType.TYPE_STEP_COUNT_DELTA
@@ -64,11 +64,12 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
     override fun onMethodCall(call: MethodCall, result: Result) {
 
         when (call.method) {
-            "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
+            "getPlatformVersion" -> result.success("Android ${Build.VERSION.RELEASE}")
 
             "requestAuthorization" -> {
-                if (hasSensorPermissionCompat()) {
-                    connect(result)
+                val useSensitive = call.argument<Boolean>("useSensitive") ?: false
+                if (!useSensitive || hasSensorPermissionCompat()) {
+                    connect(useSensitive, result)
                 } else {
                     this.deferredResult = result
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) { // Pacify lint (checked in hasSensorPermissionCompat)
@@ -78,7 +79,7 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
 
             }
 
-            "isAuthorized" -> result.success(isAuthorized())
+            "isAuthorized" -> result.success(isAuthorized(call.argument<Boolean>("useSensitive") ?: false))
 
             "getBasicHealthData" -> result.success(HashMap<String, String>())
 
@@ -189,9 +190,9 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
             || ContextCompat.checkSelfPermission(activity, Manifest.permission.BODY_SENSORS) == PackageManager.PERMISSION_GRANTED)
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (requestCode == GOOGLE_FIT_PERMISSIONS_REQUEST_CODE) {
+        if (requestCode == GOOGLE_FIT_PERMISSIONS_REQUEST_CODE || requestCode == GOOGLE_FIT_SENSITIVE_PERMISSIONS_REQUEST_CODE) {
             if (resultCode == Activity.RESULT_OK) {
-                listOf(stepsDataType, weightDataType, heartRateDataType).forEach {
+                listOfNotNull(stepsDataType, weightDataType, if (requestCode == GOOGLE_FIT_SENSITIVE_PERMISSIONS_REQUEST_CODE) heartRateDataType else null).forEach {
                     recordFitnessData(it) { success ->
                         Log.i(TAG, "Record $it success: $success!")
 
@@ -218,26 +219,26 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
         return mapOf("timestamp" to millisSinceEpoc, "value" to value.toInt(), "sourceApp" to sourceApp)
     }
 
-    private fun isAuthorized(): Boolean {
-        if (!hasSensorPermissionCompat()) {
+    private fun isAuthorized(useSensitive: Boolean): Boolean {
+        if (useSensitive && !hasSensorPermissionCompat()) {
             return false
         }
-        val fitnessOptions = getFitnessOptions()
+        val fitnessOptions = getFitnessOptions(useSensitive)
         val account = GoogleSignIn.getAccountForExtension(activity, fitnessOptions)
         return GoogleSignIn.hasPermissions(account, fitnessOptions)
     }
 
-    private fun connect(result: Result) {
-        val fitnessOptions = getFitnessOptions()
+    private fun connect(useSensitive: Boolean, result: Result) {
+        val fitnessOptions = getFitnessOptions(useSensitive)
 
-        if (!isAuthorized()) {
+        if (!isAuthorized(useSensitive)) {
             deferredResult = result
 
             val client = GoogleSignIn.getClient(activity, GoogleSignInOptions.DEFAULT_SIGN_IN)
             client.signOut().addOnCompleteListener {
                 GoogleSignIn.requestPermissions(
                         activity,
-                        GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,
+                        if (useSensitive) GOOGLE_FIT_SENSITIVE_PERMISSIONS_REQUEST_CODE else GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,
                         GoogleSignIn.getAccountForExtension(activity, fitnessOptions),
                         fitnessOptions)
             }
@@ -247,7 +248,8 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
     }
 
     private fun recordFitnessData(type: DataType, callback: (Boolean) -> Unit) {
-        Fitness.getRecordingClient(activity, GoogleSignIn.getAccountForExtension(activity, getFitnessOptions()))
+        val fitnessOptions = FitnessOptions.builder().addDataType(type).build()
+        Fitness.getRecordingClient(activity, GoogleSignIn.getAccountForExtension(activity, fitnessOptions))
                 .subscribe(type)
                 .addOnSuccessListener {
                     callback(true)
@@ -259,17 +261,18 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
 
     @SuppressLint("UseSparseArrays") // Dart doesn't know sparse arrays
     private fun getStepsInRange(start: Long, end: Long, duration: Int, unit: TimeUnit, result: (Map<Long, Int>?, Throwable?) -> Unit) {
-        val gsa = GoogleSignIn.getAccountForExtension(activity, getFitnessOptions())
+        val fitnessOptions = FitnessOptions.builder().addDataType(stepsDataType).addDataType(aggregatedDataType).build()
+        val gsa = GoogleSignIn.getAccountForExtension(activity, fitnessOptions)
 
         val ds = DataSource.Builder()
                 .setAppPackageName("com.google.android.gms")
-                .setDataType(DataType.TYPE_STEP_COUNT_DELTA)
+                .setDataType(stepsDataType)
                 .setType(DataSource.TYPE_DERIVED)
                 .setStreamName("estimated_steps")
                 .build()
 
         val request = DataReadRequest.Builder()
-                .aggregate(ds, DataType.AGGREGATE_STEP_COUNT_DELTA)
+                .aggregate(ds)
                 .bucketByTime(duration, unit)
                 .setTimeRange(start, end, TimeUnit.MILLISECONDS)
                 .build()
@@ -278,7 +281,7 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
 
         Thread {
             try {
-                val readDataResult = Tasks.await<DataReadResponse>(response)
+                val readDataResult = Tasks.await(response)
                 Log.d(TAG, "buckets count: ${readDataResult.buckets.size}")
 
                 val map = HashMap<Long, Int>() // need to return to Dart so can't use sparse array
@@ -313,18 +316,19 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
     }
 
     private fun getHeartRateInRange(start: Long, end: Long, result: (List<DataPoint>?, Throwable?) -> Unit) {
-        val gsa = GoogleSignIn.getAccountForExtension(activity, getFitnessOptions())
+        val fitnessOptions = FitnessOptions.builder().addDataType(heartRateDataType).build()
+        val gsa = GoogleSignIn.getAccountForExtension(activity, fitnessOptions)
 
         val request = DataReadRequest.Builder()
                 .setTimeRange(start, end, TimeUnit.MILLISECONDS)
-                .read(DataType.TYPE_HEART_RATE_BPM)
+                .read(heartRateDataType)
                 .build()
 
         val response = Fitness.getHistoryClient(activity, gsa).readData(request)
 
         Thread {
             try {
-                val readDataResult = Tasks.await<DataReadResponse>(response)
+                val readDataResult = Tasks.await(response)
                 Log.d(TAG, "datasets count: ${readDataResult.dataSets.size}")
 
                 if (readDataResult.dataSets.isEmpty()) {
@@ -356,13 +360,14 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
     }
 
     private fun getWeight(startTime: Long, endTime: Long, result: (Map<Long, Float>?, Throwable?) -> Unit) {
-        val gsa = GoogleSignIn.getAccountForExtension(activity, getFitnessOptions())
+        val fitnessOptions = FitnessOptions.builder().addDataType(weightDataType).build()
+        val gsa = GoogleSignIn.getAccountForExtension(activity, fitnessOptions)
 
         val request = DataReadRequest.Builder().read(DataType.TYPE_WEIGHT)
                 .setTimeRange(startTime, endTime, TimeUnit.MILLISECONDS)
                 .bucketByTime(1, TimeUnit.DAYS)
                 .setLimit(1)
-                .build();
+                .build()
 
         val response = Fitness.getHistoryClient(activity, gsa).readData(request)
 
@@ -372,7 +377,7 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
                 val readDataResult = Tasks.await(response)
                 val dp = readDataResult.buckets.lastOrNull()?.dataSets?.lastOrNull()?.dataPoints?.lastOrNull()
                 val lastWeight = dp?.getValue(weightDataType.fields[0])?.asFloat()
-                val dateInMillis = dp?.getTimestamp(TimeUnit.MILLISECONDS);
+                val dateInMillis = dp?.getTimestamp(TimeUnit.MILLISECONDS)
 
                 if (dateInMillis != null) {
                     map = HashMap<Long, Float>()
@@ -392,12 +397,16 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
         }.start()
     }
 
-    private fun getFitnessOptions() = FitnessOptions.builder()
-            .addDataType(stepsDataType, FitnessOptions.ACCESS_READ)
-            .addDataType(aggregatedDataType, FitnessOptions.ACCESS_READ)
-            .addDataType(weightDataType, FitnessOptions.ACCESS_READ)
-            .addDataType(heartRateDataType, FitnessOptions.ACCESS_READ)
-            .build()
+    private fun getFitnessOptions(useSensitive: Boolean): FitnessOptions {
+        val builder = FitnessOptions.builder()
+                .addDataType(stepsDataType, FitnessOptions.ACCESS_READ)
+                .addDataType(aggregatedDataType, FitnessOptions.ACCESS_READ)
+                .addDataType(weightDataType, FitnessOptions.ACCESS_READ)
+        if (useSensitive) {
+            builder.addDataType(heartRateDataType, FitnessOptions.ACCESS_READ)
+        }
+        return builder.build()
+    }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
         return when (requestCode) {
@@ -405,7 +414,7 @@ class FlutterHealthFitPlugin(private val activity: Activity) : MethodCallHandler
                 val result = this.deferredResult!!
                 this.deferredResult = null
                 if (grantResults?.isNotEmpty() == true && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    connect(result)
+                    connect(true, result)
                 } else {
                     result.error("PERMISSION_DENIED", "User refused", null)
                 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 30 09:31:43 IDT 2020
+#Tue Dec 22 11:25:29 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/lib/flutter_health_fit.dart
+++ b/lib/flutter_health_fit.dart
@@ -47,13 +47,23 @@ class FlutterHealthFit {
   /// (for example, in an app update).
   ///
   /// On Android this method works as expected.
-  Future<bool> get isAuthorized async {
-    final status = await _channel.invokeMethod("isAuthorized");
+  ///
+  /// [useSensitive] on Android, if this is true, will also check missing permissions of sensitive and restricted scopes, such as heart rate.
+  /// https://support.google.com/cloud/answer/9110914#sensitive-scopes
+  /// https://support.google.com/cloud/answer/9110914#restricted-scopes
+  /// On iOS has no meaning.
+  Future<bool> isAuthorized({bool useSensitive}) async {
+    final status = await _channel.invokeMethod("isAuthorized", {"useSensitive": useSensitive});
     return status;
   }
 
-  Future<bool> authorize() async {
-    return await _channel.invokeMethod('requestAuthorization');
+  /// Will ask to authorize, prompting the user if necessary.
+  /// [useSensitive] on Android, if this is true, will also ask permissions of sensitive and restricted scopes, such as heart rate.
+  /// https://support.google.com/cloud/answer/9110914#sensitive-scopes
+  /// https://support.google.com/cloud/answer/9110914#restricted-scopes
+  /// On iOS has no meaning.
+  Future<bool> authorize(bool useSensitive) async {
+    return await _channel.invokeMethod('requestAuthorization', {"useSensitive": useSensitive});
   }
 
   Future<Map<dynamic, dynamic>> get getBasicHealthData async {
@@ -83,8 +93,7 @@ class FlutterHealthFit {
   }
 
   Future<List<HeartRateSample>> _getAverageHeartRates(String methodName, int start, int end) async {
-    final averageBySource =
-        await _channel.invokeListMethod<Map>(methodName, {"start": start, "end": end});
+    final averageBySource = await _channel.invokeListMethod<Map>(methodName, {"start": start, "end": end});
 
     if (averageBySource == null || averageBySource.isEmpty) return [];
 


### PR DESCRIPTION
Added `useSensitive` toggle for Android. If false, doesn't collect heart rate and doesn't ask for body sensor Android permission.

I also modified all the `getAccountForExtension` calls to use only the relevant scopes. They used to call `getFitnessOptions` which aggregated all scopes. We don't need heart rate permission to collect steps or weight.