### PR TITLE
LMN-1431 | motionLevel-type-mismatch

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ class _MyAppState extends State<MyApp> {
   String _heartData = "";
 
   Future _authorizeHealthOrFit() async {
-    bool isAuthorized = await FlutterHealthFit().authorize();
+    bool isAuthorized = await FlutterHealthFit().authorize(true);
     setState(() {
       _isAuthorized = isAuthorized;
     });

--- a/lib/flutter_health_fit.dart
+++ b/lib/flutter_health_fit.dart
@@ -15,7 +15,15 @@ class HeartRateSample {
   final String sourceApp;
   final String sourceDevice; // may be null
 
-  int get motionLevel => Platform.isIOS && metadata != null ? metadata["HKMetadataKeyHeartRateMotionContext"] : 0;
+  int get motionLevel {
+    if (metadata != null) {
+      final heartRateMotionContext = metadata["HKMetadataKeyHeartRateMotionContext"];
+      if (heartRateMotionContext is num) {
+        return heartRateMotionContext.round();
+      }
+    }
+    return 0;
+  }
 
   HeartRateSample({this.dateTime, this.heartRate, this.metadata, this.sourceApp, this.sourceDevice});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,10 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 

--- a/test/unit/heart_rate_sample_test.dart
+++ b/test/unit/heart_rate_sample_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_health_fit/flutter_health_fit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group("HeartRateSample", () {
+    test("when motionLevel is double, expect round to int", () {
+      final sample = HeartRateSample(
+        dateTime: DateTime.now(),
+        heartRate: 64,
+        sourceApp: "com.apple.health",
+        sourceDevice: null,
+        metadata: {"HKMetadataKeyHeartRateMotionContext": 1.0},
+      );
+      expect(sample.motionLevel, equals(1));
+    });
+
+    test("when motionLevel is int, expect same number", () {
+      final sample = HeartRateSample(
+        dateTime: DateTime.now(),
+        heartRate: 64,
+        sourceApp: "com.apple.health",
+        sourceDevice: null,
+        metadata: {"HKMetadataKeyHeartRateMotionContext": 2},
+      );
+      expect(sample.motionLevel, equals(2));
+    });
+
+    test("when motionLevel is not a number, expect 0", () {
+      final sample = HeartRateSample(
+        dateTime: DateTime.now(),
+        heartRate: 64,
+        sourceApp: "com.apple.health",
+        sourceDevice: null,
+        metadata: {"HKMetadataKeyHeartRateMotionContext": "not a number"},
+      );
+      expect(sample.motionLevel, equals(0));
+    });
+
+    test("when motionLevel key not in metadata, expect motionLevel to be 0", () {
+      final sample = HeartRateSample(
+        dateTime: DateTime.now(),
+        heartRate: 64,
+        sourceApp: "com.apple.health",
+        sourceDevice: null,
+        metadata: {},
+      );
+      expect(sample.motionLevel, equals(0));
+    });
+
+    test("when no metadata, expect motionLevel to be 0", () {
+      final sample = HeartRateSample(
+        dateTime: DateTime.now(),
+        heartRate: 64,
+        sourceApp: "com.apple.health",
+        sourceDevice: null,
+      );
+      expect(sample.motionLevel, equals(0));
+    });
+  });
+}


### PR DESCRIPTION
HKMetadataKeyHeartRateMotionContext value from iOS is returned as double, and needs to be converted to int.
Added unit tests for HeartRateSample.motionLevel values for different metadata input.