### PR TITLE
getLatestHeartRateSample, getAverageWalkingHeartRate, getAverageRestingHeartRate - shouldn't add nullable type over returned expression.

### DIFF
--- a/lib/flutter_health_fit.dart
+++ b/lib/flutter_health_fit.dart
@@ -196,13 +196,13 @@ class FlutterHealthFit {
     });
   }
 
-  Future<HeartRateSample?>? getLatestHeartRateSample(int start, int end) =>
+  Future<HeartRateSample?> getLatestHeartRateSample(int start, int end) =>
       _getHeartRate("getHeartRateSample", start, end);
 
-  Future<List<HeartRateSample?>>? getAverageWalkingHeartRate(int start, int end) =>
+  Future<List<HeartRateSample>> getAverageWalkingHeartRate(int start, int end) =>
       _getAverageHeartRates("getAverageWalkingHeartRate", start, end);
 
-  Future<List<HeartRateSample?>>? getAverageRestingHeartRate(int start, int end) =>
+  Future<List<HeartRateSample>> getAverageRestingHeartRate(int start, int end) =>
       _getAverageHeartRates("getAverageRestingHeartRate", start, end);
 
   Future<HeartRateSample?> _getHeartRate(String methodName, int start, int end) async {


### PR DESCRIPTION
Should declare the same return type as the function it delegates the call to.