### PR TITLE
LMN-6185 | No implementation found for isBloodGlucoseAuthorized on Android.

### DIFF
--- a/lib/flutter_health_fit.dart
+++ b/lib/flutter_health_fit.dart
@@ -452,8 +452,10 @@ class FlutterHealthFit {
     }
   }
 
-  /// Checks if iBloodGlucose permission has been authorized
+  /// Checks if BloodGlucose permission has been authorized. Blood Glucose is never authorized on Android.
   Future<bool> isBloodGlucoseAuthorized() async {
+    if (!Platform.isIOS) return false;
+
     try {
       final status = await _channel.invokeMethod("isBloodGlucoseAuthorized");
       return status;


### PR DESCRIPTION
 - added a platform check within isBloodGlucoseAuthorized since it's not supported on Android yet.